### PR TITLE
Configure root workspace for Vercel build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# bizdevphil# bizdevphil
+# Biz Dev Phil Deployment
+
+This repository contains the Biz Dev Phil marketing site built with React and Vite. The Vite application lives in the `project/` directory, and the repository root exposes npm scripts that proxy to that workspace. This setup allows deployment platforms such as Vercel to install dependencies and run the build from the repository root.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+The commands above install dependencies and start the Vite development server for the project workspace.
+
+## Available Scripts
+
+All scripts are forwarded to the workspace under `project/`:
+
+- `npm run dev`
+- `npm run build`
+- `npm run preview`
+- `npm run lint`
+- `npm run format`
+
+Run the commands from the repository root.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bizdevphil-monorepo",
+  "private": true,
+  "workspaces": [
+    "project"
+  ],
+  "scripts": {
+    "build": "npm run build --workspace project",
+    "dev": "npm run dev --workspace project",
+    "lint": "npm run lint --workspace project",
+    "preview": "npm run preview --workspace project",
+    "format": "npm run format --workspace project"
+  }
+}


### PR DESCRIPTION
## Summary
- add a root-level package.json that forwards npm scripts to the Vite project workspace so Vercel can install dependencies and run the build
- document the workspace setup and available root scripts in the README

## Testing
- not run (npm install is blocked from reaching the public npm registry in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7cb962e248333ae97d4658c655b89