### PR TITLE
Configure Vite with React plugin

### DIFF
--- a/project/package.json
+++ b/project/package.json
@@ -16,6 +16,7 @@
     "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.1",
     "prettier": "^3.2.5",

--- a/project/vite.config.js
+++ b/project/vite.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  plugins: [react()],
   build: {
     sourcemap: false,
   },


### PR DESCRIPTION
## Summary
- add the official React plugin dependency to the Vite project
- register the React plugin so JSX files compile correctly during the build

## Testing
- npm install *(fails: registry access is blocked by the environment proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ccd2529c8333b95528cb1c2bf6b5