### PR TITLE
Implement responsive about layout and mobile navigation

### DIFF
--- a/project/src/components/Header.jsx
+++ b/project/src/components/Header.jsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { NavLink, Link, useLocation } from 'react-router-dom';
 import ThemeToggle from './ThemeToggle.jsx';
 import CTA from './CTA.jsx';
@@ -10,21 +11,20 @@ const navItems = [
 
 export default function Header({ identity }) {
   const location = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
 
   return (
     <header>
-      <div className="container flex justify-between align-center" style={{ gap: '1.5rem' }}>
+      <div className="container header-bar">
         <Link to="/" className="brand" aria-label={`${identity?.name || 'Biz Dev Phil'} home`}>
-          <div style={{ display: 'grid', gap: '0.1rem' }}>
-            <span style={{ fontFamily: 'Montserrat, sans-serif', fontWeight: 700, fontSize: '1.25rem' }}>
-              {identity?.name || 'Biz Dev Phil'}
-            </span>
-            <span className="text-muted" style={{ fontSize: '0.85rem' }}>
-              {identity?.subtitle || 'Online Brand Strategist'}
-            </span>
-          </div>
+          <span className="brand-title">{identity?.name || 'Biz Dev Phil'}</span>
         </Link>
-        <nav className="flex align-center" aria-label="Main navigation" style={{ gap: '1.5rem' }}>
+
+        <nav className="desktop-nav" aria-label="Main navigation">
           {navItems.map((item) => (
             <NavLink
               key={item.to}
@@ -38,10 +38,53 @@ export default function Header({ identity }) {
             </NavLink>
           ))}
         </nav>
-        <div className="flex align-center" style={{ gap: '1rem' }}>
+
+        <div className="header-actions">
           <ThemeToggle />
           <CTA label="Let’s Collaborate" to="/contact" />
         </div>
+
+        <button
+          type="button"
+          className="menu-toggle"
+          aria-expanded={menuOpen}
+          aria-controls="mobile-navigation"
+          onClick={() => setMenuOpen((prev) => !prev)}
+        >
+          <span className="sr-only">Toggle navigation</span>
+          <span aria-hidden="true" className={`menu-icon${menuOpen ? ' open' : ''}`}>
+            <span />
+            <span />
+            <span />
+          </span>
+        </button>
+      </div>
+
+      <div
+        id="mobile-navigation"
+        className={`mobile-nav${menuOpen ? ' open' : ''}`}
+        aria-hidden={!menuOpen}
+      >
+        <nav aria-label="Mobile main navigation">
+          <ul>
+            {navItems.map((item) => (
+              <li key={item.to}>
+                <NavLink
+                  to={item.to}
+                  className={({ isActive }) =>
+                    `nav-link${isActive ? ' active' : ''}`
+                  }
+                >
+                  {item.label}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+          <div className="mobile-nav-actions">
+            <CTA label="Let’s Collaborate" to="/contact" />
+            <ThemeToggle />
+          </div>
+        </nav>
       </div>
     </header>
   );

--- a/project/src/components/PageSectionNav.jsx
+++ b/project/src/components/PageSectionNav.jsx
@@ -7,11 +7,11 @@ const sections = [
   { id: 'brands', label: 'Brands' },
 ];
 
-export default function PageSectionNav() {
+export default function PageSectionNav({ className = '' }) {
   const active = useActiveSections(sections.map((section) => section.id));
 
   return (
-    <nav aria-label="About page sections" className="flex flex-wrap" style={{ gap: '0.75rem', marginTop: '2rem' }}>
+    <nav aria-label="About page sections" className={`page-section-nav flex flex-wrap ${className}`.trim()}>
       {sections.map((section) => (
         <button
           key={section.id}

--- a/project/src/pages/About.jsx
+++ b/project/src/pages/About.jsx
@@ -2,59 +2,204 @@ import CTA from '../components/CTA.jsx';
 import PageSectionNav from '../components/PageSectionNav.jsx';
 import content from '../data/content.json';
 
+const socialIcons = {
+  LinkedIn: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M20.45 20.45h-3.55v-5.4c0-1.29-.02-2.95-1.8-2.95-1.81 0-2.09 1.41-2.09 2.86v5.49H9.46V9h3.41v1.56h.05c.47-.89 1.62-1.83 3.34-1.83 3.57 0 4.23 2.35 4.23 5.4v6.32ZM5.34 7.39a2.06 2.06 0 1 1 0-4.12 2.06 2.06 0 0 1 0 4.12ZM7.12 20.45H3.55V9H7.12v11.45ZM22.23 0H1.77C.79 0 0 .77 0 1.72v20.56C0 23.22.79 24 1.77 24h20.46c.98 0 1.77-.78 1.77-1.72V1.72C24 .77 23.21 0 22.23 0Z"
+      />
+    </svg>
+  ),
+  Facebook: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M22 12a10 10 0 1 0-11.56 9.88v-7h-2.3V12h2.3V9.79c0-2.27 1.35-3.53 3.42-3.53.99 0 2.03.18 2.03.18v2.22h-1.14c-1.12 0-1.47.7-1.47 1.41V12h2.5l-.4 2.88h-2.1v7A10 10 0 0 0 22 12Z"
+      />
+    </svg>
+  ),
+  X: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M20.98 3.5h-3.1l-4.31 5.72L9.86 3.5H3.02l7.41 10.38L3.36 20.5h3.1l4.58-6.07 3.93 6.07h6.84l-7.68-10.46 7.85-6.54Z"
+      />
+    </svg>
+  ),
+  Instagram: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10Zm0 8.2A3.2 3.2 0 1 1 15.2 12 3.21 3.21 0 0 1 12 15.2ZM17.75 6.46a1.17 1.17 0 1 1 1.17-1.17 1.17 1.17 0 0 1-1.17 1.17ZM21.6 7a5.86 5.86 0 0 0-1.6-4.15A5.86 5.86 0 0 0 15.85 1.2h-7.7A5.86 5.86 0 0 0 4 2.85 5.86 5.86 0 0 0 2.4 7v7.7A5.86 5.86 0 0 0 4 18.85 5.86 5.86 0 0 0 8.15 20.4h7.7a5.86 5.86 0 0 0 4.15-1.55 5.86 5.86 0 0 0 1.55-4.15Zm-2 7.76a3.91 3.91 0 0 1-1 2.58 3.91 3.91 0 0 1-2.58 1h-7.7a3.91 3.91 0 0 1-2.58-1 3.91 3.91 0 0 1-1-2.58V7a3.91 3.91 0 0 1 1-2.58 3.91 3.91 0 0 1 2.58-1h7.7a3.91 3.91 0 0 1 2.58 1A3.91 3.91 0 0 1 19.6 7Z"
+      />
+    </svg>
+  ),
+  YouTube: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M21.58 7.2a2.61 2.61 0 0 0-1.84-1.85C17.87 5 12 5 12 5s-5.87 0-7.74.35A2.61 2.61 0 0 0 2.42 7.2 27.32 27.32 0 0 0 2 12a27.32 27.32 0 0 0 .42 4.8 2.61 2.61 0 0 0 1.84 1.85C6.13 19 12 19 12 19s5.87 0 7.74-.35a2.61 2.61 0 0 0 1.84-1.85A27.32 27.32 0 0 0 22 12a27.32 27.32 0 0 0-.42-4.8ZM10 15V9l5.2 3Z"
+      />
+    </svg>
+  ),
+  TikTok: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M19.5 7.61a4.6 4.6 0 0 1-2.88-1V14a5.86 5.86 0 1 1-5.88-5.83 6 6 0 0 1 .91.07V10a3.84 3.84 0 0 0-.91-.11 3.67 3.67 0 1 0 3.67 3.66V2h2.2a4.51 4.51 0 0 0 3.23 3.17Z"
+      />
+    </svg>
+  ),
+};
+
+const contactIcons = {
+  phone: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M20.85 15.54 18 14.9a1.7 1.7 0 0 0-1.61.49l-1.76 1.81a13.3 13.3 0 0 1-5.83-5.83l1.8-1.77a1.7 1.7 0 0 0 .49-1.61L10.45 5.2a1.7 1.7 0 0 0-1.92-1.31l-2.9.58a1.7 1.7 0 0 0-1.35 1.66 15.95 15.95 0 0 0 15.95 15.95 1.7 1.7 0 0 0 1.66-1.35l.58-2.9a1.7 1.7 0 0 0-1.32-1.9Z"
+      />
+    </svg>
+  ),
+  email: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M20.5 4h-17A1.5 1.5 0 0 0 2 5.5v13A1.5 1.5 0 0 0 3.5 20h17a1.5 1.5 0 0 0 1.5-1.5v-13A1.5 1.5 0 0 0 20.5 4Zm-.32 2-7.68 6.08L3.82 6ZM4 18v-8.35l8 6.34 8-6.34V18Z"
+      />
+    </svg>
+  ),
+  location: (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M12 2a7 7 0 0 0-7 7c0 5.25 7 13 7 13s7-7.75 7-13a7 7 0 0 0-7-7Zm0 9.5A2.5 2.5 0 1 1 14.5 9 2.5 2.5 0 0 1 12 11.5Z"
+      />
+    </svg>
+  ),
+};
+
+const getSocialIcon = (label) => socialIcons[label] ?? (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <circle cx="12" cy="12" r="10" fill="currentColor" />
+  </svg>
+);
+
 export default function About() {
-  const { identity, brands } = content;
+  const { identity, brands, contact } = content;
+
+  const contactItems = [
+    {
+      icon: contactIcons.phone,
+      label: 'Phone',
+      value: contact.phone,
+      href: `tel:${contact.phone.replace(/[^\d+]/g, '')}`,
+    },
+    {
+      icon: contactIcons.email,
+      label: 'Email',
+      value: contact.email,
+      href: `mailto:${contact.email}`,
+    },
+    {
+      icon: contactIcons.location,
+      label: 'Location',
+      value: contact.address,
+      href: contact.mapLink,
+    },
+  ];
 
   return (
-    <div className="container stack-lg">
-      <section id="about-top" data-section className="section" style={{ paddingBottom: '3rem' }}>
-        <div className="stack-lg">
-          <div className="stack-md">
-            <h1>{identity.name}</h1>
-            <p className="lead">{identity.value}</p>
-            <CTA />
+    <div className="container">
+      <div className="about-layout">
+        <aside className="about-sidebar" aria-label="Profile overview">
+          <div className="about-photo" aria-hidden="true" />
+          <div className="stack-sm">
+            <h2 className="about-name">{identity.name}</h2>
+            <p className="about-role">{identity.subtitle}</p>
           </div>
-          <div className="stack-md">
-            <div className="stack-sm">
-              <h2 style={{ fontSize: '1.5rem' }}>{identity.subtitle}</h2>
-              <p className="text-muted">
-                I help growing brands remove friction online so more guests book, buy, and inquire. From websites to automation,
-                every project is built to deliver measurable outcomes.
-              </p>
-            </div>
-            <div className="social-links" aria-label="Social links">
-              {identity.socials.map((social) => (
-                <a key={social.label} href={social.href}>
-                  <span aria-hidden="true">⬈</span>
-                  {social.label}
-                </a>
+          <div className="about-contact">
+            <h3>Contact</h3>
+            <ul>
+              {contactItems.map((item) => (
+                <li key={item.label}>
+                  <a href={item.href} target={item.label === 'Location' ? '_blank' : undefined} rel={item.label === 'Location' ? 'noopener noreferrer' : undefined}>
+                    <span className="about-icon" aria-hidden="true">
+                      {item.icon}
+                    </span>
+                    <span>
+                      <span className="about-contact-label">{item.label}</span>
+                      <span className="about-contact-value">{item.value}</span>
+                    </span>
+                  </a>
+                </li>
               ))}
-            </div>
+            </ul>
           </div>
-        </div>
-        <PageSectionNav />
-      </section>
+          <div className="about-socials">
+            <h3>Connect</h3>
+            <ul>
+              {identity.socials.map((social) => (
+                <li key={social.label}>
+                  <a href={social.href} target="_blank" rel="noopener noreferrer">
+                    <span className="about-icon" aria-hidden="true">
+                      {getSocialIcon(social.label)}
+                    </span>
+                    {social.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </aside>
 
-      <section id="testimonials" data-section className="section" style={{ paddingTop: '3rem' }}>
-        <div className="stack-md">
-          <h2>Testimonials</h2>
-          <div className="notice">Testimonials coming soon.</div>
-        </div>
-      </section>
+        <div className="about-content">
+          <div className="about-section-nav">
+            <PageSectionNav />
+          </div>
 
-      <section id="brands" data-section className="section" style={{ paddingTop: '3rem' }}>
-        <div className="stack-md">
-          <h2>Brands I’ve partnered with</h2>
-          <ul className="stack-sm">
-            {brands.map((brand) => (
-              <li key={brand} className="card" style={{ fontWeight: 600 }}>
-                {brand}
-              </li>
-            ))}
-          </ul>
-          <CTA label="Plan the next win" to="/contact" variant="secondary" />
+          <section id="about-top" data-section className="section about-hero">
+            <div className="stack-lg">
+              <div className="stack-md">
+                <h1>{identity.name}</h1>
+                <p className="lead">{identity.value}</p>
+                <CTA />
+              </div>
+              <div className="stack-md">
+                <div className="stack-sm">
+                  <h2 style={{ fontSize: '1.5rem' }}>{identity.subtitle}</h2>
+                  <p className="text-muted">
+                    I help growing brands remove friction online so more guests book, buy, and inquire. From websites to automation,
+                    every project is built to deliver measurable outcomes.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section id="testimonials" data-section className="section about-section">
+            <div className="stack-md">
+              <h2>Testimonials</h2>
+              <div className="notice">Testimonials coming soon.</div>
+            </div>
+          </section>
+
+          <section id="brands" data-section className="section about-section">
+            <div className="stack-md">
+              <h2>Brands I’ve partnered with</h2>
+              <ul className="stack-sm">
+                {brands.map((brand) => (
+                  <li key={brand} className="card" style={{ fontWeight: 600 }}>
+                    {brand}
+                  </li>
+                ))}
+              </ul>
+              <CTA label="Plan the next win" to="/contact" variant="secondary" />
+            </div>
+          </section>
         </div>
-      </section>
+      </div>
     </div>
   );
 }

--- a/project/src/styles/global.css
+++ b/project/src/styles/global.css
@@ -162,6 +162,100 @@ footer nav a {
   font-size: 0.95rem;
 }
 
+.header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  min-height: var(--header-height);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+.brand-title {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+
+.desktop-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.menu-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid rgba(124, 58, 237, 0.4);
+  background: var(--surface-2);
+  color: inherit;
+}
+
+.menu-icon {
+  display: grid;
+  gap: 6px;
+}
+
+.menu-icon span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  transition: transform var(--transition-base), opacity var(--transition-base);
+}
+
+.menu-icon.open span:nth-child(1) {
+  transform: translateY(4px) rotate(45deg);
+}
+
+.menu-icon.open span:nth-child(2) {
+  opacity: 0;
+}
+
+.menu-icon.open span:nth-child(3) {
+  transform: translateY(-4px) rotate(-45deg);
+}
+
+.mobile-nav {
+  display: none;
+}
+
+.mobile-nav nav {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.mobile-nav ul {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.mobile-nav-actions {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.page-section-nav {
+  gap: 0.75rem;
+  margin-top: 2rem;
+}
+
 .nav-link {
   position: relative;
   padding-bottom: 0.35rem;
@@ -299,6 +393,205 @@ main {
 
 section + section {
   border-top: 1px solid rgba(124, 58, 237, 0.12);
+}
+
+@media (max-width: 900px) {
+  .desktop-nav,
+  .header-actions {
+    display: none;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+  }
+
+  .mobile-nav {
+    display: block;
+    padding: 1.25rem 1.5rem 1.75rem;
+    background: var(--surface);
+    border-top: 1px solid rgba(124, 58, 237, 0.12);
+  }
+
+  .mobile-nav:not(.open) {
+    display: none;
+  }
+
+  .mobile-nav nav {
+    gap: 1.25rem;
+  }
+}
+
+.about-layout {
+  display: grid;
+  gap: 2.5rem;
+  padding: 3rem 0;
+}
+
+.about-sidebar {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  display: grid;
+  gap: 1.75rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.about-photo {
+  width: min(100%, 220px);
+  aspect-ratio: 1 / 1;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.4), rgba(36, 24, 64, 0.75));
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  color: var(--accent-contrast);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.about-photo::after {
+  content: 'Photo';
+}
+
+.about-name {
+  margin: 0;
+  font-size: 1.65rem;
+}
+
+.about-role {
+  margin: 0;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.about-contact ul,
+.about-socials ul {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.about-contact a,
+.about-socials a {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition-base), transform var(--transition-base);
+}
+
+.about-contact a:hover,
+.about-contact a:focus-visible,
+.about-socials a:hover,
+.about-socials a:focus-visible {
+  background: var(--surface-2);
+  transform: translateY(-2px);
+}
+
+.about-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: rgba(124, 58, 237, 0.12);
+  color: var(--accent);
+}
+
+.about-icon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.about-contact-label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.about-contact-value {
+  display: block;
+  font-weight: 600;
+}
+
+.about-content {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.about-section-nav {
+  order: 0;
+}
+
+.about-section-nav .page-section-nav {
+  margin-top: 0;
+}
+
+.about-hero {
+  order: 1;
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+.about-section {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+@media (max-width: 767px) {
+  .about-layout {
+    padding: 2rem 0 3rem;
+  }
+
+  .about-section-nav {
+    order: 1;
+  }
+
+  .about-hero {
+    order: 0;
+  }
+
+  .about-section-nav .page-section-nav {
+    margin-top: 2rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .about-layout {
+    grid-template-columns: minmax(260px, 320px) 1fr;
+  }
+
+  .about-sidebar {
+    position: sticky;
+    top: calc(var(--header-height) + 1.5rem);
+    align-self: start;
+  }
+
+  .about-photo {
+    width: 100%;
+  }
+
+  .about-content {
+    gap: 3rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .about-layout {
+    gap: 3rem;
+  }
+
+  .about-sidebar {
+    padding: 2.25rem;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- add a fixed-profile sidebar for the About page on tablet/desktop that surfaces contact information and social icons
- move the section navigation ahead of the hero on larger viewports while keeping the mobile-first layout for phones
- update the header with a simplified sticky brand lockup and a hamburger-driven mobile navigation
- expand global styles to support the new sidebar layout and responsive header behavior

## Testing
- npm run build *(fails: missing @vitejs/plugin-react in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d08ccd508333aaa730eaa6ef5062