### PR TITLE
Improve mobile layouts and calls to action

### DIFF
--- a/project/src/components/Header.jsx
+++ b/project/src/components/Header.jsx
@@ -20,9 +20,26 @@ export default function Header({ identity }) {
   return (
     <header>
       <div className="container header-bar">
-        <Link to="/" className="brand" aria-label={`${identity?.name || 'Biz Dev Phil'} home`}>
-          <span className="brand-title">{identity?.name || 'Biz Dev Phil'}</span>
-        </Link>
+        <div className="brand-group">
+          <button
+            type="button"
+            className="menu-toggle"
+            aria-expanded={menuOpen}
+            aria-controls="mobile-navigation"
+            onClick={() => setMenuOpen((prev) => !prev)}
+          >
+            <span className="sr-only">Toggle navigation</span>
+            <span aria-hidden="true" className={`menu-icon${menuOpen ? ' open' : ''}`}>
+              <span />
+              <span />
+              <span />
+            </span>
+          </button>
+
+          <Link to="/" className="brand" aria-label={`${identity?.name || 'Biz Dev Phil'} home`}>
+            <span className="brand-title">{identity?.name || 'Biz Dev Phil'}</span>
+          </Link>
+        </div>
 
         <nav className="desktop-nav" aria-label="Main navigation">
           {navItems.map((item) => (
@@ -43,21 +60,6 @@ export default function Header({ identity }) {
           <ThemeToggle />
           <CTA label="Let’s Collaborate" to="/contact" />
         </div>
-
-        <button
-          type="button"
-          className="menu-toggle"
-          aria-expanded={menuOpen}
-          aria-controls="mobile-navigation"
-          onClick={() => setMenuOpen((prev) => !prev)}
-        >
-          <span className="sr-only">Toggle navigation</span>
-          <span aria-hidden="true" className={`menu-icon${menuOpen ? ' open' : ''}`}>
-            <span />
-            <span />
-            <span />
-          </span>
-        </button>
       </div>
 
       <div

--- a/project/src/components/PageSectionNav.jsx
+++ b/project/src/components/PageSectionNav.jsx
@@ -2,7 +2,7 @@ import scrollToHash from '../utils/scrollToHash.js';
 import useActiveSections from '../hooks/useActiveSections.js';
 
 const sections = [
-  { id: 'about-top', label: 'About' },
+  { id: 'about-top', label: 'Info' },
   { id: 'testimonials', label: 'Testimonials' },
   { id: 'brands', label: 'Brands' },
 ];

--- a/project/src/pages/About.jsx
+++ b/project/src/pages/About.jsx
@@ -155,16 +155,18 @@ export default function About() {
         </aside>
 
         <div className="about-content">
-          <div className="about-section-nav">
-            <PageSectionNav />
-          </div>
-
           <section id="about-top" data-section className="section about-hero">
             <div className="stack-lg">
               <div className="stack-md">
-                <h1>{identity.name}</h1>
+                <div className="stack-sm">
+                  <h1>Jezrel Phil Nacar</h1>
+                  <PageSectionNav className="hero-nav" />
+                </div>
                 <p className="lead">{identity.value}</p>
-                <CTA />
+                <div className="stack-sm">
+                  <CTA label="View my services" to="/services" variant="secondary" />
+                  <CTA />
+                </div>
               </div>
               <div className="stack-md">
                 <div className="stack-sm">

--- a/project/src/pages/Contact.jsx
+++ b/project/src/pages/Contact.jsx
@@ -103,6 +103,14 @@ export default function Contact() {
           <button type="submit" className="btn" disabled={status === 'submitting'}>
             {status === 'submitting' ? 'Sending…' : 'Send Message'}
           </button>
+          <a
+            href="https://m.me/bizdevphil"
+            className="btn btn-secondary"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Chat in Messenger
+          </a>
           {feedback ? (
             <p id="form-feedback" className={status === 'success' ? '' : 'text-muted'}>
               {feedback}

--- a/project/src/styles/global.css
+++ b/project/src/styles/global.css
@@ -170,6 +170,12 @@ footer nav a {
   min-height: var(--header-height);
 }
 
+.brand-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .brand {
   display: inline-flex;
   align-items: center;
@@ -254,6 +260,10 @@ footer nav a {
 .page-section-nav {
   gap: 0.75rem;
   margin-top: 2rem;
+}
+
+.page-section-nav.hero-nav {
+  margin-top: 1rem;
 }
 
 .nav-link {
@@ -422,7 +432,8 @@ section + section {
 }
 
 .about-layout {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 2.5rem;
   padding: 3rem 0;
 }
@@ -527,14 +538,6 @@ section + section {
   gap: 2.5rem;
 }
 
-.about-section-nav {
-  order: 0;
-}
-
-.about-section-nav .page-section-nav {
-  margin-top: 0;
-}
-
 .about-hero {
   order: 1;
   padding-top: 3rem;
@@ -551,28 +554,30 @@ section + section {
     padding: 2rem 0 3rem;
   }
 
-  .about-section-nav {
+  .about-sidebar {
+    order: 2;
+  }
+
+  .about-content {
     order: 1;
-  }
-
-  .about-hero {
-    order: 0;
-  }
-
-  .about-section-nav .page-section-nav {
-    margin-top: 2rem;
   }
 }
 
 @media (min-width: 768px) {
   .about-layout {
+    display: grid;
     grid-template-columns: minmax(260px, 320px) 1fr;
   }
 
   .about-sidebar {
+    order: initial;
     position: sticky;
     top: calc(var(--header-height) + 1.5rem);
     align-self: start;
+  }
+
+  .about-content {
+    order: initial;
   }
 
   .about-photo {

--- a/project/src/styles/utils.css
+++ b/project/src/styles/utils.css
@@ -150,12 +150,17 @@
   }
 
   header .container {
-    flex-direction: column;
-    gap: 0.75rem;
-    align-items: flex-start;
+    flex-direction: row;
+    gap: 1rem;
+    align-items: center;
   }
 
   .tab-list {
     padding-bottom: 0.75rem;
+  }
+
+  footer nav.flex {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- group the mobile menu toggle with the site title so the hamburger icon and "Biz Dev Phil" stay aligned
- restructure the About page hero with the "Jezrel Phil Nacar" title, top-aligned section nav, and an added "View my services" CTA while moving the sidebar below content on small screens
- add a Messenger contact button beneath the contact form submission and stack footer links vertically on mobile for better legibility

## Testing
- npm run build *(fails: missing @vitejs/plugin-react because the package registry returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d922fd748333b3e8c258045fe405