### PR TITLE
Center footer layout and prioritize about info section

### DIFF
--- a/project/src/components/Footer.jsx
+++ b/project/src/components/Footer.jsx
@@ -4,7 +4,7 @@ export default function Footer({ identity }) {
   const year = new Date().getFullYear();
   return (
     <footer>
-      <div className="container stack-md">
+      <div className="container stack-md footer-content">
         <nav aria-label="Footer navigation" className="flex flex-wrap" style={{ gap: '1rem' }}>
           <Link to="/">About</Link>
           <Link to="/services">Services</Link>

--- a/project/src/styles/global.css
+++ b/project/src/styles/global.css
@@ -162,6 +162,16 @@ footer nav a {
   font-size: 0.95rem;
 }
 
+.footer-content {
+  justify-items: center;
+  text-align: center;
+}
+
+footer nav.flex {
+  justify-content: center;
+  align-items: center;
+}
+
 .header-bar {
   display: flex;
   align-items: center;
@@ -539,7 +549,6 @@ section + section {
 }
 
 .about-hero {
-  order: 1;
   padding-top: 3rem;
   padding-bottom: 3rem;
 }

--- a/project/src/styles/utils.css
+++ b/project/src/styles/utils.css
@@ -161,6 +161,6 @@
 
   footer nav.flex {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
   }
 }


### PR DESCRIPTION
## Summary
- center the footer navigation and copy across breakpoints for consistent alignment
- remove the layout override so the About page info section renders before testimonials

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7dd3ef0dc83338858893d6ddcc63f