### PR TITLE
Improve preview card imagery

### DIFF
--- a/project/src/components/PreviewCard.jsx
+++ b/project/src/components/PreviewCard.jsx
@@ -47,7 +47,7 @@ export default function PreviewCard({ title, result, badges = [], link, previews
   };
 
   return (
-    <article className="card stack-md">
+    <article className="card card--preview">
       {activePreview ? (
         <figure className="preview-media">
           <button
@@ -77,38 +77,30 @@ export default function PreviewCard({ title, result, badges = [], link, previews
               </span>
             ) : null}
           </button>
-          {(activePreview.label || hasAlternate) && (
-            <figcaption className="preview-media-label">
-              {activePreview.label || 'Preview'}
-              {hasAlternate && activePreviewIndex === 0 && normalizedPreviews[1]?.label
-                ? ` · Hover to see ${normalizedPreviews[1].label}`
-                : null}
-            </figcaption>
-          )}
         </figure>
       ) : (
         <div className="gradient-thumb" aria-hidden="true"></div>
       )}
-      <div>
+      <div className="preview-card-body stack-md">
         <h3 style={{ marginBottom: '0.25rem' }}>{title}</h3>
         <p className="text-muted">{result}</p>
+        {badges?.length ? (
+          <div className="badge-group">
+            {badges.map((badge) => (
+              <span className="badge" key={badge}>
+                {badge}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        {link ? (
+          <div>
+            <a href={link} target="_blank" rel="noopener noreferrer" className="text-muted">
+              View
+            </a>
+          </div>
+        ) : null}
       </div>
-      {badges?.length ? (
-        <div className="badge-group">
-          {badges.map((badge) => (
-            <span className="badge" key={badge}>
-              {badge}
-            </span>
-          ))}
-        </div>
-      ) : null}
-      {link ? (
-        <div>
-          <a href={link} target="_blank" rel="noopener noreferrer" className="text-muted">
-            View
-          </a>
-        </div>
-      ) : null}
     </article>
   );
 }

--- a/project/src/styles/global.css
+++ b/project/src/styles/global.css
@@ -106,6 +106,31 @@ section[data-section] {
   transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
 
+.card--preview {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.card--preview .preview-media {
+  margin: 0;
+}
+
+.card--preview .preview-media-button {
+  border-radius: 0;
+  background: none;
+}
+
+.card--preview .preview-media-button img {
+  aspect-ratio: 16 / 10;
+  height: 100%;
+}
+
+.card--preview .preview-card-body {
+  padding: 1.75rem;
+}
+
 .card:hover,
 .card:focus-within {
   transform: translateY(-4px);


### PR DESCRIPTION
## Summary
- let service preview images fill the card edge-to-edge with a dedicated flush layout
- remove redundant hover labels so only the core project details remain visible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e226e1dd2083339c7300d86f4d2eb7