### PR TITLE
Make About sidebar independently scrollable on desktop

### DIFF
--- a/project/src/styles/global.css
+++ b/project/src/styles/global.css
@@ -644,6 +644,12 @@ section + section {
   .about-sidebar {
     padding: 2.25rem;
   }
+
+  .about-sidebar {
+    max-height: calc(100vh - var(--header-height) - 3rem);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- limit the About page sidebar height on large screens and enable its own vertical scrolling
- keep existing sticky positioning so the main content can scroll independently while preserving spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e22afae0c883338a0bd942fc55ecc5