### PR TITLE
Adjust About page partner list and layout spacing

### DIFF
--- a/project/src/data/content.json
+++ b/project/src/data/content.json
@@ -36,13 +36,14 @@
   },
   "brands": [
     "ProtoCode Solutions",
-    "Tune Media Collective",
+    "Tuni Studios",
     "BoutiqueBeach Resort",
-    "Everyone's Goals",
-    "Hey! Challenger",
-    "Lucia AI Concierge",
+    "PBN Youth",
+    "Impaytus",
+    "Lucia Decode",
     "KonsultaMD",
-    "Pinoyship Japan"
+    "Pinoyship Japan",
+    "32+ SaaS founders in Reddit"
   ],
   "testimonials": [],
   "services": [

--- a/project/src/pages/About.jsx
+++ b/project/src/pages/About.jsx
@@ -114,7 +114,7 @@ export default function About() {
   ];
 
   return (
-    <div className="container">
+    <div className="container about-container">
       <div className="about-layout">
         <aside className="about-sidebar" aria-label="Profile overview">
           {portraitSrc ? (

--- a/project/src/styles/global.css
+++ b/project/src/styles/global.css
@@ -466,6 +466,10 @@ section + section {
   }
 }
 
+.about-container {
+  width: min(100% - 2.5rem, 1240px);
+}
+
 .about-layout {
   display: flex;
   flex-direction: column;
@@ -611,9 +615,13 @@ section + section {
 }
 
 @media (min-width: 768px) {
+  .about-container {
+    width: min(100% - 3rem, 1280px);
+  }
+
   .about-layout {
     display: grid;
-    grid-template-columns: minmax(260px, 320px) 1fr;
+    grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
   }
 
   .about-sidebar {
@@ -632,13 +640,17 @@ section + section {
   }
 
   .about-content {
-    gap: 3rem;
+    gap: clamp(3rem, 4vw, 3.75rem);
   }
 }
 
 @media (min-width: 1024px) {
+  .about-container {
+    width: min(100% - 4rem, 1340px);
+  }
+
   .about-layout {
-    gap: 3rem;
+    gap: clamp(3.25rem, 6vw, 4.5rem);
   }
 
   .about-sidebar {


### PR DESCRIPTION
## Summary
- rename several About page partner names and add the "32+ SaaS founders in Reddit" brand entry in the data source
- widen the About page container and refine the sidebar grid sizing so the main content has more room without affecting mobile layouts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68e22d5930a08333bb0ec1e6a9583b59