### PR TITLE
Add automation service cards

### DIFF
--- a/project/src/data/content.json
+++ b/project/src/data/content.json
@@ -251,6 +251,40 @@
           "alt": "Placeholder preview of the Savore website."
         }
       ]
+    },
+    {
+      "tab": "Automations",
+      "title": "Update Emails",
+      "result": "Syncs announcements and follow-ups automatically across the channels your team already uses.",
+      "badges": [
+        "N8N",
+        "Discord",
+        "webhook"
+      ]
+    },
+    {
+      "tab": "Automations",
+      "title": "Automated Chats",
+      "result": "Builds guided chat journeys that respond instantly and qualify leads around the clock.",
+      "badges": [
+        "ManyChat"
+      ]
+    },
+    {
+      "tab": "Automations",
+      "title": "Client Onboarding Automation",
+      "result": "Delivers welcome packets, next steps, and reminders without manual chasing.",
+      "badges": [
+        "Mailjet"
+      ]
+    },
+    {
+      "tab": "Automations",
+      "title": "Performance Reports",
+      "result": "Compiles campaign metrics into ready-to-share snapshots on a recurring schedule.",
+      "badges": [
+        "SEO"
+      ]
     }
   ],
   "researches": [


### PR DESCRIPTION
## Summary
- add data entries for the Automation tab covering Update Emails, Automated Chats, Client Onboarding Automation, and Performance Reports
- tag each new automation service with the requested tooling labels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5f15e207c83339bd1343ae5c8c99e