### PR TITLE
Add icon fallbacks for automation service cards

### DIFF
--- a/project/package.json
+++ b/project/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "lucide-react": "^0.379.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3"

--- a/project/src/components/PreviewCard.jsx
+++ b/project/src/components/PreviewCard.jsx
@@ -1,5 +1,13 @@
 import { useMemo, useState } from 'react';
+import { Mail, Bot, ClipboardCheck, BarChart, LayoutGrid } from 'lucide-react';
 import resolveAssetPath from '../utils/assetPath.js';
+
+const ICON_MAP = {
+  'Update Emails': Mail,
+  'Automated Chats': Bot,
+  'Client Onboarding Automation': ClipboardCheck,
+  'Performance Reports': BarChart,
+};
 
 export default function PreviewCard({ title, result, badges = [], link, previews = [] }) {
   const normalizedPreviews = useMemo(
@@ -19,6 +27,7 @@ export default function PreviewCard({ title, result, badges = [], link, previews
   const activePreview = hasPreviews
     ? normalizedPreviews[Math.min(activePreviewIndex, normalizedPreviews.length - 1)]
     : null;
+  const IconComponent = ICON_MAP[title] || LayoutGrid;
 
   const handleToggle = () => {
     if (hasAlternate) {
@@ -79,7 +88,9 @@ export default function PreviewCard({ title, result, badges = [], link, previews
           </button>
         </figure>
       ) : (
-        <div className="gradient-thumb" aria-hidden="true"></div>
+        <div className="preview-icon" aria-hidden="true">
+          <IconComponent className="preview-icon-symbol" />
+        </div>
       )}
       <div className="preview-card-body stack-md">
         <h3 style={{ marginBottom: '0.25rem' }}>{title}</h3>

--- a/project/src/styles/utils.css
+++ b/project/src/styles/utils.css
@@ -40,6 +40,21 @@
   mix-blend-mode: screen;
 }
 
+.preview-icon {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, rgba(36, 24, 64, 0.85), rgba(16, 12, 32, 0.95));
+  display: grid;
+  place-items: center;
+}
+
+.preview-icon-symbol {
+  width: 3rem;
+  height: 3rem;
+  color: var(--accent);
+}
+
 .preview-media {
   display: grid;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- add lucide icons as the preview fallback for automation service cards
- style the new icon container to match the existing accent palette
- register lucide-react as a dependency for the project

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5f8fdcd90833397a8784e804a631b