### PR TITLE
Add social content services with platform icon display

### DIFF
--- a/project/src/components/PreviewCard.jsx
+++ b/project/src/components/PreviewCard.jsx
@@ -1,5 +1,16 @@
 import { useMemo, useState } from 'react';
-import { Mail, Bot, ClipboardCheck, BarChart, LayoutGrid } from 'lucide-react';
+import {
+  Mail,
+  Bot,
+  ClipboardCheck,
+  BarChart,
+  LayoutGrid,
+  Facebook,
+  Twitter,
+  Youtube,
+  Instagram,
+  Video,
+} from 'lucide-react';
 import resolveAssetPath from '../utils/assetPath.js';
 
 const ICON_MAP = {
@@ -7,9 +18,27 @@ const ICON_MAP = {
   'Automated Chats': Bot,
   'Client Onboarding Automation': ClipboardCheck,
   'Performance Reports': BarChart,
+  'Video Editing': Video,
 };
 
-export default function PreviewCard({ title, result, badges = [], link, previews = [] }) {
+const PLATFORM_ICON_MAP = {
+  Facebook,
+  Twitter,
+  Youtube,
+  Instagram,
+  Video,
+  Tiktok: Video,
+  Threads: Video,
+};
+
+export default function PreviewCard({
+  title,
+  result,
+  badges = [],
+  link,
+  previews = [],
+  icons = [],
+}) {
   const normalizedPreviews = useMemo(
     () =>
       (Array.isArray(previews) ? previews : [])
@@ -28,6 +57,19 @@ export default function PreviewCard({ title, result, badges = [], link, previews
     ? normalizedPreviews[Math.min(activePreviewIndex, normalizedPreviews.length - 1)]
     : null;
   const IconComponent = ICON_MAP[title] || LayoutGrid;
+  const platformIcons = useMemo(
+    () =>
+      (Array.isArray(icons) ? icons : [])
+        .map((name) => {
+          const PlatformIcon = PLATFORM_ICON_MAP[name];
+          if (!PlatformIcon) {
+            return null;
+          }
+          return { name, PlatformIcon };
+        })
+        .filter(Boolean),
+    [icons]
+  );
 
   const handleToggle = () => {
     if (hasAlternate) {
@@ -94,6 +136,13 @@ export default function PreviewCard({ title, result, badges = [], link, previews
       )}
       <div className="preview-card-body stack-md">
         <h3 style={{ marginBottom: '0.25rem' }}>{title}</h3>
+        {platformIcons.length ? (
+          <div className="preview-card-icons" aria-hidden="true">
+            {platformIcons.map(({ name, PlatformIcon }) => (
+              <PlatformIcon key={name} className="preview-card-icon" />
+            ))}
+          </div>
+        ) : null}
         <p className="text-muted">{result}</p>
         {badges?.length ? (
           <div className="badge-group">

--- a/project/src/data/content.json
+++ b/project/src/data/content.json
@@ -285,6 +285,34 @@
       "badges": [
         "SEO"
       ]
+    },
+    {
+      "tab": "Content",
+      "title": "Social Media Handling",
+      "result": "Full-package consistent management across Facebook, TikTok, Instagram, X, YouTube, & Threads.",
+      "badges": [
+        "Management",
+        "Marketing"
+      ],
+      "icons": [
+        "Facebook",
+        "Tiktok",
+        "Instagram",
+        "Twitter",
+        "Youtube",
+        "Threads"
+      ]
+    },
+    {
+      "tab": "Content",
+      "title": "Video Editing",
+      "result": "Fast, social-optimized video editing workflow built for creators and brands.",
+      "badges": [
+        "Capcut"
+      ],
+      "icons": [
+        "Video"
+      ]
     }
   ],
   "researches": [

--- a/project/src/pages/Services.jsx
+++ b/project/src/pages/Services.jsx
@@ -40,6 +40,7 @@ export default function Services() {
             badges={service.badges}
             link={service.link}
             previews={service.previews}
+            icons={service.icons}
           />
         ))}
         {showResearch &&

--- a/project/src/styles/global.css
+++ b/project/src/styles/global.css
@@ -131,6 +131,18 @@ section[data-section] {
   padding: 1.75rem;
 }
 
+.preview-card-icons {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  color: var(--accent);
+}
+
+.preview-card-icon {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
 .card:hover,
 .card:focus-within {
   transform: translateY(-4px);


### PR DESCRIPTION
## Summary
- add Social Media Handling and Video Editing services with associated platform metadata
- render optional platform icon rows in preview cards using lucide-react icons styled with the accent color
- pass icon lists from the services page and update preview card styles for the new layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5fe50e5588333824880398f915721