### PR TITLE
Update about page marketing copy and add testimonial carousel

### DIFF
--- a/project/src/components/TestimonialsCarousel.jsx
+++ b/project/src/components/TestimonialsCarousel.jsx
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+
+export default function TestimonialsCarousel({ testimonials = [] }) {
+  const items = useMemo(() => testimonials.filter(Boolean), [testimonials]);
+
+  if (!items.length) {
+    return null;
+  }
+
+  return (
+    <div className="testimonial-carousel" role="list" aria-label="Testimonials">
+      {items.map(({ quote, author, role, location }) => (
+        <article key={`${author}-${quote.slice(0, 12)}`} className="card testimonial-card" role="listitem">
+          <p className="testimonial-quote">“{quote}”</p>
+          <div className="testimonial-meta">
+            <p className="testimonial-author">{author}</p>
+            <p className="testimonial-role">{role}</p>
+            <p className="testimonial-location">{location}</p>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/project/src/data/content.json
+++ b/project/src/data/content.json
@@ -1,7 +1,7 @@
 {
   "identity": {
     "name": "Biz Dev Phil",
-    "subtitle": "Online Brand Strategist",
+    "subtitle": "Online Brand & Marketing Strategist",
     "value": "Strategy-first partner for founders ready to scale: I build conversion-driven websites, run full-funnel marketing, and lead content production so launches stay on schedule, teams stay aligned, and every moment moves people from curious to committed advocates for your brand across all channels daily.",
     "portrait": {
       "src": "images/profile/portrait.jpg",
@@ -45,7 +45,20 @@
     "Pinoyship Japan",
     "32+ SaaS founders in Reddit"
   ],
-  "testimonials": [],
+  "testimonials": [
+    {
+      "quote": "Honestly, we’re lucky to have crossed paths with someone capable of moving so naturally between creative narrative, market psychology, and emotional precision. You understand how to feel the crowd.",
+      "author": "Pablo Garcia",
+      "role": "Founder of Lucia Decode",
+      "location": "Oviedo, Asturias Spain"
+    },
+    {
+      "quote": "At only 20 years old, you already have the skills to create apps, automations, and ads. That’s truly impressive.",
+      "author": "Michael Reyes",
+      "role": "CEO of Protocode Solutions",
+      "location": "Cavite"
+    }
+  ],
   "services": [
     {
       "tab": "Apps & Tools",

--- a/project/src/pages/About.jsx
+++ b/project/src/pages/About.jsx
@@ -1,10 +1,11 @@
 import AboutSidebar from '../components/AboutSidebar.jsx';
 import CTA from '../components/CTA.jsx';
 import PageSectionNav from '../components/PageSectionNav.jsx';
+import TestimonialsCarousel from '../components/TestimonialsCarousel.jsx';
 import content from '../data/content.json';
 
 export default function About() {
-  const { identity, brands, contact } = content;
+  const { identity, brands, contact, testimonials } = content;
 
   return (
     <div className="container about-container">
@@ -29,8 +30,8 @@ export default function About() {
                 <div className="stack-sm">
                   <h2 style={{ fontSize: '1.5rem' }}>{identity.subtitle}</h2>
                   <p className="text-muted">
-                    I help growing brands remove friction online so more guests book, buy, and inquire. From websites to automation,
-                    every project is built to deliver measurable outcomes.
+                    I help growing brands remove friction online so more guests book, buy, and inquire. From websites to automation
+                    and full-funnel marketing systems, every project is built to deliver measurable outcomes.
                   </p>
                 </div>
               </div>
@@ -39,8 +40,11 @@ export default function About() {
 
           <section id="testimonials" data-section className="section about-section">
             <div className="stack-md">
-              <h2>Testimonials</h2>
-              <div className="notice">Testimonials coming soon.</div>
+              <div className="stack-sm">
+                <h2>Testimonials</h2>
+                <p className="text-muted">What collaborators say about our work together.</p>
+              </div>
+              <TestimonialsCarousel testimonials={testimonials} />
             </div>
           </section>
 

--- a/project/src/styles/global.css
+++ b/project/src/styles/global.css
@@ -180,6 +180,51 @@ section[data-section] {
   box-shadow: var(--shadow-elevated);
 }
 
+.testimonial-carousel {
+  display: flex;
+  gap: 1.5rem;
+  overflow-x: auto;
+  padding: 0.5rem 0 0.5rem 0.25rem;
+  margin: 0 -0.25rem;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+
+.testimonial-carousel::-webkit-scrollbar {
+  height: 0.5rem;
+}
+
+.testimonial-carousel::-webkit-scrollbar-thumb {
+  background: var(--surface-2);
+  border-radius: 999px;
+}
+
+.testimonial-card {
+  flex: 0 0 clamp(280px, 45vw, 360px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  scroll-snap-align: start;
+}
+
+.testimonial-quote {
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.testimonial-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.testimonial-author {
+  font-weight: 700;
+  color: var(--text);
+}
+
 .badge {
   display: inline-flex;
   align-items: center;
@@ -209,7 +254,8 @@ section[data-section] {
 .btn:hover,
 .btn:focus-visible {
   transform: translateY(-1px);
-  background: #6930d8;
+  background: var(--accent);
+  background: color-mix(in srgb, var(--accent) 85%, #ffffff 15%);
 }
 
 .btn-secondary {

--- a/project/src/styles/variables.css
+++ b/project/src/styles/variables.css
@@ -15,7 +15,7 @@
   --surface-2: #f2f2f7;
   --text: #111114;
   --muted: #545466;
-  --accent: #7c3aed;
+  --accent: #281627;
   --accent-contrast: #ffffff;
   --brand-green: #556b2f;
   --brand-green-contrast: #ffffff;


### PR DESCRIPTION
## Summary
- highlight marketing alongside automation in the about page introduction and subtitle
- add testimonial data and render it in a swipeable carousel on the about page
- align light theme accent color updates with the refreshed brand palette

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691028c3c5b883339e1e6ce5280fd06f)